### PR TITLE
Add Jest tests and lint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,28 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Linting
+
+This project uses **ESLint** with TypeScript support. All required packages are listed in `package.json` and will be installed when you run:
+
+```sh
+npm i
+```
+
+To check your code style, execute:
+
+```sh
+npm run lint
+```
+
+## Testing
+
+Unit tests are written with **Jest**. After installing dependencies, run:
+
+```sh
+npm test
+```
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/9dd3a537-09ac-44e4-9067-741456cb5bfd) and click on Share -> Publish.

--- a/__tests__/convertApi.test.ts
+++ b/__tests__/convertApi.test.ts
@@ -1,0 +1,31 @@
+import { ConvertApiService, PasswordRequiredError } from '../src/services/convertApi';
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+
+const mockFile = new File(['dummy'], 'test.pdf', { type: 'application/pdf' });
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('ConvertApiService', () => {
+  it('returns download url on success', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ Files: [{ Url: 'http://example.com/file.xlsx', FileName: 'file.xlsx' }] })
+    }) as any;
+
+    const result = await ConvertApiService.convertPdfToExcel(mockFile);
+    expect(result).toEqual({ downloadUrl: 'http://example.com/file.xlsx', fileName: 'file.xlsx' });
+  });
+
+  it('throws PasswordRequiredError when api indicates password protection', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ Code: 5003, Message: 'password protected' }),
+      status: 400,
+      statusText: 'Bad Request'
+    }) as any;
+
+    await expect(ConvertApiService.convertPdfToExcel(mockFile)).rejects.toBeInstanceOf(PasswordRequiredError);
+  });
+});

--- a/__tests__/googleDrive.test.ts
+++ b/__tests__/googleDrive.test.ts
@@ -1,0 +1,21 @@
+import { GoogleDriveService } from '../src/services/googleDrive';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+describe('GoogleDriveService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  it('uploads file when initialized', async () => {
+    localStorage.setItem('gdrive_initialized', 'true');
+    const promise = GoogleDriveService.uploadFile('http://example.com/file.xlsx', 'file.xlsx');
+    jest.runAllTimers();
+    const url = await promise;
+    expect(url).toMatch(/https:\/\/drive.google.com\/file\/d\/.*\/view/);
+  });
+
+  it('throws error if not initialized', async () => {
+    await expect(GoogleDriveService.uploadFile('http://example.com/file.xlsx', 'file.xlsx')).rejects.toThrow('Google Drive service not initialized');
+  });
+});

--- a/__tests__/useFileConversion.test.ts
+++ b/__tests__/useFileConversion.test.ts
@@ -1,0 +1,44 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { useFileConversion } from '../src/hooks/useFileConversion';
+import { ConvertApiService } from '../src/services/convertApi';
+import { GoogleDriveService } from '../src/services/googleDrive';
+
+jest.mock('../src/hooks/use-toast', () => ({
+  useToast: () => ({ toast: jest.fn() })
+}));
+
+jest.mock('../src/services/convertApi');
+jest.mock('../src/services/googleDrive');
+
+const mockConvert = ConvertApiService.convertPdfToExcel as jest.Mock;
+const mockUpload = GoogleDriveService.uploadFile as jest.Mock;
+
+const file = new File(['dummy'], 'test.pdf', { type: 'application/pdf' });
+
+describe('useFileConversion', () => {
+  beforeEach(() => {
+    mockConvert.mockResolvedValue({ downloadUrl: 'http://example.com/file.xlsx', fileName: 'file.xlsx' });
+    mockUpload.mockResolvedValue('https://drive.google.com/file/d/id/view');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('converts file and sets download url', async () => {
+    const { result } = renderHook(() => useFileConversion(false));
+    act(() => {
+      result.current.setFile(file);
+      result.current.setGdprConsent(true);
+    });
+
+    await act(async () => {
+      await result.current.handleConvert();
+    });
+
+    expect(mockConvert).toHaveBeenCalled();
+    expect(result.current.downloadUrl).toBe('http://example.com/file.xlsx');
+    expect(result.current.conversionComplete).toBe(true);
+  });
+});

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true }]
+  },
+  extensionsToTreatAsEsm: ['.ts', '.tsx']
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -79,6 +80,10 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.11",
+    "@testing-library/react": "^14.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- document how to run ESLint and tests
- set up Jest config and script
- add Jest and testing libs as dev dependencies
- create tests for `useFileConversion`, `convertApi`, and `googleDrive` services

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68455d69e9a483209882555ec6eb7f10