### PR TITLE
Add AI-based PDF conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
+    "pdfjs-dist": "^3.11.174",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
@@ -60,6 +61,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
+    "xlsx": "^0.18.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/hooks/useFileConversion.ts
+++ b/src/hooks/useFileConversion.ts
@@ -3,6 +3,7 @@ import { useState, useCallback } from 'react';
 import { useToast } from "@/hooks/use-toast";
 import { ConvertApiService, PasswordRequiredError } from "@/services/convertApi";
 import { GoogleDriveService } from "@/services/googleDrive";
+import { PdfAiService } from "@/services/pdfAi";
 
 interface UseFileConversionReturn {
   file: File | null;
@@ -16,6 +17,7 @@ interface UseFileConversionReturn {
   setFile: (file: File | null) => void;
   setGdprConsent: (consent: boolean) => void;
   handleConvert: (password?: string) => Promise<void>;
+  handleAiConvert: () => Promise<void>;
   handleReset: () => void;
   handleDownload: () => void;
   handleOpenInDrive: () => void;
@@ -116,6 +118,77 @@ export function useFileConversion(isDriveConfigured: boolean): UseFileConversion
     }
   }, [file, gdprConsent, isDriveConfigured, toast]);
 
+  const handleAiConvert = useCallback(async () => {
+    if (!gdprConsent) {
+      toast({
+        title: "GDPR Consent Required",
+        description: "Please consent to our data processing policy before proceeding.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!file) {
+      toast({
+        title: "No file selected",
+        description: "Please select a file first.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsConverting(true);
+    setProgress(0);
+
+    try {
+      const conversionResult = await PdfAiService.convertPdfToExcel(
+        file,
+        setProgress
+      );
+
+      let driveFileUrl = "";
+
+      if (isDriveConfigured) {
+        try {
+          driveFileUrl = await GoogleDriveService.uploadFile(
+            conversionResult.downloadUrl,
+            conversionResult.fileName,
+            setProgress
+          );
+          setDriveUrl(driveFileUrl);
+        } catch (driveError) {
+          console.error("Error uploading file to Google Drive:", driveError);
+          toast({
+            title: "Google Drive Upload Failed",
+            description: "Your file was converted but couldn't be uploaded to Google Drive. You can still download it directly.",
+            variant: "warning",
+          });
+        }
+      } else {
+        setProgress(100);
+      }
+
+      setDownloadUrl(conversionResult.downloadUrl);
+      setIsConverting(false);
+      setConversionComplete(true);
+
+      toast({
+        title: "Conversion Complete",
+        description: driveFileUrl
+          ? "Your Excel file is saved to Google Drive and ready to download."
+          : "Your Excel file is ready to download.",
+      });
+    } catch (error) {
+      console.error("Error in AI conversion process:", error);
+      setIsConverting(false);
+      toast({
+        title: "Conversion Failed",
+        description: "There was an error converting your PDF file with AI. Please try again.",
+        variant: "destructive",
+      });
+    }
+  }, [file, gdprConsent, isDriveConfigured, toast]);
+
   const handleReset = useCallback(() => {
     setFile(null);
     setConversionComplete(false);
@@ -172,6 +245,7 @@ export function useFileConversion(isDriveConfigured: boolean): UseFileConversion
     setFile,
     setGdprConsent,
     handleConvert,
+    handleAiConvert,
     handleReset,
     handleDownload,
     handleOpenInDrive,

--- a/src/services/pdfAi.ts
+++ b/src/services/pdfAi.ts
@@ -1,0 +1,105 @@
+import { toast } from "sonner";
+import { getDocument, GlobalWorkerOptions, version as pdfjsVersion } from "pdfjs-dist";
+import * as XLSX from "xlsx";
+import { ConversionResult } from "./convertApi";
+
+const OPENAI_API_KEY = import.meta.env.VITE_OPENAI_API_KEY;
+const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+
+/**
+ * Service for converting PDFs to Excel using AI extraction
+ */
+export class PdfAiService {
+  /** Extract text from a PDF file */
+  static async extractText(file: File): Promise<string> {
+    try {
+      const arrayBuffer = await file.arrayBuffer();
+      GlobalWorkerOptions.workerSrc =
+        `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsVersion}/pdf.worker.min.js`;
+      const pdf = await getDocument({ data: arrayBuffer }).promise;
+      let text = "";
+      for (let i = 1; i <= pdf.numPages; i++) {
+        const page = await pdf.getPage(i);
+        const content = await page.getTextContent();
+        text += (content.items as any[]).map((it: any) => it.str).join(" ") + "\n";
+      }
+      return text;
+    } catch (error) {
+      console.error("Failed to extract text from PDF:", error);
+      toast.error("Failed to read PDF file");
+      throw error;
+    }
+  }
+
+  /** Send extracted text to the AI API to get structured JSON */
+  static async sendToAiApi(text: string): Promise<any> {
+    try {
+      const response = await fetch(OPENAI_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: "gpt-4o",
+          messages: [
+            {
+              role: "system",
+              content:
+                "Parse the following bank statement text and return an array of objects with fields Date, Description, Amount, Balance in JSON format.",
+            },
+            { role: "user", content: text },
+          ],
+          temperature: 0,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`AI request failed: ${response.statusText}`);
+      }
+      const result = await response.json();
+      return JSON.parse(result.choices[0].message.content);
+    } catch (error) {
+      console.error("AI API error:", error);
+      toast.error("Failed to analyze PDF with AI");
+      throw error;
+    }
+  }
+
+  /** Convert a JSON object to an Excel download URL */
+  static jsonToExcel(data: any): string {
+    const worksheet = XLSX.utils.json_to_sheet(data);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, "Sheet1");
+    const wbout = XLSX.write(workbook, { bookType: "xlsx", type: "array" });
+    const blob = new Blob([wbout], {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    });
+    return URL.createObjectURL(blob);
+  }
+
+  /**
+   * Convert PDF to Excel using AI parsing
+   */
+  static async convertPdfToExcel(
+    file: File,
+    onProgress?: (progress: number) => void
+  ): Promise<ConversionResult> {
+    try {
+      if (onProgress) onProgress(5);
+      const text = await this.extractText(file);
+      if (onProgress) onProgress(40);
+      const json = await this.sendToAiApi(text);
+      if (onProgress) onProgress(70);
+      const downloadUrl = this.jsonToExcel(json);
+      if (onProgress) onProgress(100);
+      return {
+        downloadUrl,
+        fileName: file.name.replace(/\.pdf$/i, ".xlsx"),
+      };
+    } catch (error) {
+      console.error("AI conversion failed:", error);
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add pdfAi service for extracting PDF text and creating Excel via OpenAI
- allow useFileConversion to trigger AI-based conversion
- include pdfjs-dist and xlsx packages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455d6921a0832093bd0d7884e6cdf4