### PR TITLE
Add Privacy page

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,8 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Privacy Policy
+
+Access the privacy policy in the running app at `/privacy`.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Privacy from "./pages/Privacy";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/privacy" element={<Privacy />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function Privacy() {
+  return (
+    <div className="container max-w-3xl py-8 space-y-4">
+      <h1 className="text-3xl font-bold">Privacy Policy</h1>
+      <p>
+        We only process your files to convert them to Excel. Files are encrypted
+        in transit and removed from our servers automatically after 24 hours.
+      </p>
+      <p>
+        By using this service you agree that your data may be temporarily
+        processed for the sole purpose of performing the conversion.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a privacy policy page
- register /privacy route in the app
- mention the privacy policy in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68455d67c9f083208ad1c2942b865f8b