### PR TITLE
Fix regex for pdf filename replacement

### DIFF
--- a/src/services/convertApi.ts
+++ b/src/services/convertApi.ts
@@ -88,7 +88,7 @@ export class ConvertApiService {
       // Return the download URL and file name
       return {
         downloadUrl: result.Files[0].Url,
-        fileName: result.Files[0].FileName || file.name.replace('.pdf', '.xlsx')
+        fileName: result.Files[0].FileName || file.name.replace(/\.pdf$/i, '.xlsx')
       };
     } catch (error) {
       // Check if it's a password protected error


### PR DESCRIPTION
## Summary
- use regex to replace PDF file extension when fallback to the original filename

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68455d66edec8320936ddc934870429e