### PR TITLE
Add server proxy for ConvertAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -60,7 +61,9 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "express": "^4.19.2",
+    "multer": "^1.4.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,46 @@
+import express from 'express';
+import multer from 'multer';
+
+const CONVERT_API_KEY = 'secret_gwACX7APZCZuyT88';
+const API_BASE_URL = 'https://v2.convertapi.com';
+
+const app = express();
+const upload = multer();
+
+app.post('/api/convert', upload.single('File'), async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: 'No file provided' });
+    }
+
+    const formData = new FormData();
+    formData.append('File', new Blob([req.file.buffer], { type: req.file.mimetype }), req.file.originalname);
+    formData.append('StoreFile', 'true');
+    if (req.body.Password) {
+      formData.append('Password', req.body.Password);
+    }
+
+    const response = await fetch(`${API_BASE_URL}/convert/pdf/to/xlsx?Secret=${CONVERT_API_KEY}`, {
+      method: 'POST',
+      body: formData,
+      headers: {
+        'Authorization': `Bearer ${CONVERT_API_KEY}`
+      }
+    });
+
+    const data = await response.text();
+    res.status(response.status);
+    for (const [key, value] of response.headers.entries()) {
+      res.setHeader(key, value);
+    }
+    res.send(data);
+  } catch (err) {
+    console.error('Error forwarding to ConvertAPI:', err);
+    res.status(500).json({ error: 'Conversion failed' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/services/convertApi.ts
+++ b/src/services/convertApi.ts
@@ -1,8 +1,8 @@
 
 import { toast } from "sonner";
 
-const CONVERT_API_KEY = "secret_gwACX7APZCZuyT88";
-const API_BASE_URL = "https://v2.convertapi.com";
+// Backend endpoint that proxies requests to ConvertAPI
+const API_BASE_URL = "/api";
 
 export interface ConversionResult {
   downloadUrl: string;
@@ -47,17 +47,11 @@ export class ConvertApiService {
       
       if (onProgress) onProgress(15);
 
-      // Make the API request
-      const response = await fetch(
-        `${API_BASE_URL}/convert/pdf/to/xlsx?Secret=${CONVERT_API_KEY}`,
-        {
-          method: "POST",
-          body: formData,
-          headers: {
-            "Authorization": `Bearer ${CONVERT_API_KEY}`
-          }
-        }
-      );
+      // Make the API request to the backend proxy
+      const response = await fetch(`${API_BASE_URL}/convert`, {
+        method: "POST",
+        body: formData,
+      });
 
       if (onProgress) onProgress(50);
 


### PR DESCRIPTION
## Summary
- add an Express server that proxies `/api/convert` to ConvertAPI using the secret key
- call the new backend endpoint from `ConvertApiService`
- add express and multer dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68455d5aee448320bd154d273ed533ac